### PR TITLE
Trailing comma in constructor parameters is not compatible with PHP 7.x

### DIFF
--- a/Block/Order/Item/Renderer/DefaultRenderer.php
+++ b/Block/Order/Item/Renderer/DefaultRenderer.php
@@ -45,7 +45,7 @@ class DefaultRenderer extends \Magento\Framework\View\Element\Template
         \Magento\Framework\Stdlib\StringUtils $string,
         \Magento\Catalog\Model\Product\OptionFactory $productOptionFactory,
         \Magento\Framework\Registry $registry,
-        array $data = [],
+        array $data = []
     ) {
         $this->string = $string;
         $this->_productOptionFactory = $productOptionFactory;


### PR DESCRIPTION
Remove trailing comma from constructor. This is the only place where I could find it.